### PR TITLE
Support for multiple containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ must be unique.
                 - /dev/bus/usb/003/003:/dev/bus/usb/001/001
             volumes:
                 - /docker_binds/pwr_stat/pwrstat.yaml:/pwrstat.yaml:ro
+                # Optionally override the powerstatd configuration file
                 - /docker_binds/pwr_stat/pwrstatd.conf:/etc/pwrstatd.conf:ro
             healthcheck:
                 test: ["CMD", "curl", "-sI", "http://127.0.0.1:5002/pwrstat"]

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 This is a container for the CyberPower 'pwrstat' utility.
 Basic GET support for a single JSON object response for
 all parameters of the UPS are implemented.
-MQTT is also supported, with broker, port, and topic
-options all being specified in the config file.
+MQTT is also supported, with broker, port, client_id and topic
+options all being specified in the config file. Note: client_id
+must be unique. 
 
 ## Usage
 
@@ -23,6 +24,7 @@ options all being specified in the config file.
                 - /dev/bus/usb/003/003:/dev/bus/usb/001/001
             volumes:
                 - /docker_binds/pwr_stat/pwrstat.yaml:/pwrstat.yaml:ro
+                - /docker_binds/pwr_stat/pwrstatd.conf:/etc/pwrstatd.conf:ro
             healthcheck:
                 test: ["CMD", "curl", "-sI", "http://127.0.0.1:5002/pwrstat"]
                 interval: 30s
@@ -40,6 +42,7 @@ options all being specified in the config file.
     mqtt:
         broker: "192.168.1.100"
         port: 1883
+        client_id: "pwrstat_mqtt"
         topic: "sensors/basement/power/ups"
         refresh: 3
         qos: 0

--- a/example-docker-compose.yaml
+++ b/example-docker-compose.yaml
@@ -1,19 +1,21 @@
 ---
-version: "2.4"
+version: '2.4'
 services:
-  pwr_stat:
-    container_name: pwr_stat
-    hostname: pwr_stat
-    restart: always
-    image: dwinks/pwrstat_docker:latest
-    devices:
-      - /dev/bus/usb/003/003:/dev/bus/usb/001/001
-    volumes:
-      - /docker_binds/pwr_stat/pwrstat.yaml:/pwrstat.yaml:ro
-    healthcheck:
-    test: ["CMD", "curl", "-sI", "http://127.0.0.1:5002/pwrstat"]
-    interval: 30s
-    timeout: 1s
-    retries: 24
-    privileged: true
-    network_mode: host
+    pwr_stat:
+        container_name: pwr_stat
+        hostname: pwr_stat
+        restart: always
+        image: dwinks/pwrstat_docker:latest
+        devices:
+            - /dev/bus/usb/003/003:/dev/bus/usb/001/001
+        volumes:
+            - /docker_binds/pwr_stat/pwrstat.yaml:/pwrstat.yaml:ro
+            # Optionally override the powerstatd configuration file
+            - /docker_binds/pwr_stat/pwrstatd.conf:/etc/pwrstatd.conf:ro
+        healthcheck:
+            test: ["CMD", "curl", "-sI", "http://127.0.0.1:5002/pwrstat"]
+            interval: 30s
+            timeout: 1s
+            retries: 24
+        privileged: true
+        network_mode: host

--- a/pwrstat.yaml
+++ b/pwrstat.yaml
@@ -2,6 +2,7 @@
 mqtt:
   broker: "192.168.1.100"
   port: 1883
+  client_id: "pwrstat_mqtt"
   topic: "sensors/basement/power/ups"
   refresh: 30
   qos: 0

--- a/pwrstat_api.py
+++ b/pwrstat_api.py
@@ -98,6 +98,7 @@ class Pwrstat:
             {
                 vol.Required("broker"): vol.All(str, vol.Length(min=7, max=15), vol.Match(VALID_IP_REGEX)),
                 vol.Required("port"): int,
+                vol.Required("client_id"): str,
                 vol.Required("topic"): str,
                 vol.Required("refresh"): int,
                 vol.Required("qos"): int,

--- a/pwrstat_api.py
+++ b/pwrstat_api.py
@@ -47,7 +47,7 @@ class PwrstatMqtt:
         """
         self.mqtt_config = kwargs["mqtt_config"]
         self.client = mqtt.Client(
-            client_id="pwrstat_mqtt",
+            client_id=self.mqtt_config["client_id"],
             clean_session=True,
             userdata=None,
             protocol=mqtt.MQTTv311,


### PR DESCRIPTION
Set mqtt client_id from yaml config file to allow multiple containers to run so multiple UPS can be monitored. Suggest that pwrstatd.conf can be overridden.