### PR TITLE
add curl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY *.py requirements.txt PPL-1.3.3-64bit.deb init.sh pwrstat.yaml /
 
 RUN apt-get update && apt-get dist-upgrade -y && \
     apt-get install -y procps && \
+    apt-get install -y curl && \
     chmod +x /init.sh && chmod +x /pwrstat_api.py && \
     pip install --trusted-host pypi.python.org -r requirements.txt && \
     apt-get install -y /PPL-1.3.3-64bit.deb && \


### PR DESCRIPTION
fixes https://github.com/DanielWinks/pwrstat_docker/issues/9

Add "apt-get curl" to dockerfile so container health check works